### PR TITLE
Add Termux setup script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Tools](#-tools)
 - [Bots](#-bots)
 - [Resources](#-resources)
+- [Termux (Non-Root) Setup](#-termux-non-root-setup)
 
 ## [↑](#contents) Search Engines
 
@@ -128,3 +129,20 @@
 * [Telegram Network Visualization](https://medium.com/dataseries/telegram-network-visualization-tracing-forwards-and-mentions-f75746712fcf)
 * [How to Get Data From Telegram Using Python](https://betterprogramming.pub/how-to-get-data-from-telegram-82af55268a4b)
 * [Tips how to find private, hidden, personal groups and channels](https://telegra.ph/Tips-how-to-find-private-hidden-personal-groups-and-channels---TelegramPrivateChatLeaks-08-10)
+
+## [↑](#contents) Termux (Non-Root) Setup
+
+This repository can be accessed from Android using [Termux](https://termux.dev) without root.
+
+1. Download and run the setup script:
+
+   ```bash
+   curl -O https://raw.githubusercontent.com/ItIsMeCall911/Awesome-Telegram-OSINT/main/termux_setup.sh
+   bash termux_setup.sh
+   ```
+
+2. Open the list of resources:
+
+   ```bash
+   less "$HOME/Awesome-Telegram-OSINT/README.md"
+   ```

--- a/termux_setup.sh
+++ b/termux_setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+if ! command -v pkg >/dev/null 2>&1; then
+  echo "Error: pkg command not found. Run this script inside Termux." >&2
+  exit 1
+fi
+
+pkg update -y && pkg upgrade -y
+pkg install -y git python nodejs
+
+REPO_DIR="$HOME/Awesome-Telegram-OSINT"
+if [ -d "$REPO_DIR/.git" ]; then
+  git -C "$REPO_DIR" pull --ff-only
+else
+  git clone https://github.com/ItIsMeCall911/Awesome-Telegram-OSINT.git "$REPO_DIR"
+fi
+
+echo "Repository ready at $REPO_DIR"
+echo "View the list with: less \"$REPO_DIR/README.md\""

--- a/termux_setup.sh
+++ b/termux_setup.sh
@@ -9,11 +9,12 @@ fi
 pkg update -y && pkg upgrade -y
 pkg install -y git python nodejs
 
+REPO_URL="https://github.com/ItIsMeCall911/Awesome-Telegram-OSINT.git"
 REPO_DIR="$HOME/Awesome-Telegram-OSINT"
 if [ -d "$REPO_DIR/.git" ]; then
   git -C "$REPO_DIR" pull --ff-only
 else
-  git clone https://github.com/ItIsMeCall911/Awesome-Telegram-OSINT.git "$REPO_DIR"
+  git clone "$REPO_URL" "$REPO_DIR"
 fi
 
 echo "Repository ready at $REPO_DIR"


### PR DESCRIPTION
## Summary
- add setup script for non-root Termux environments
- document Termux setup instructions in README

## Testing
- `./termux_setup.sh` *(fails: pkg command not found; run this script inside Termux)*
- `npx --yes markdownlint-cli README.md` *(fails: multiple markdownlint rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ae30f0b000832894555bbbb2dbc07f